### PR TITLE
Ability to rename media files with parts

### DIFF
--- a/config/media_rename.yml
+++ b/config/media_rename.yml
@@ -3,12 +3,14 @@ PLEX_PORT:
 PLEX_HOST:  
 MOVIE_TEMPLATE: "\
 {{target_path}}/\
-{% if video_format == '2K' or video_format == '4K' %}Movies_HQ/\
-{% else %}Movies/\
-{%endif%}\
+{% if video_format == '4K' %}Movies_HQ/{% else %}Movies/{%endif%}\
 {{title}} ({{year}}){% if tag %} {{tags}}{% endif %}/\
 {{title}} ({{year}}) {% if tag %}{{tags}} {% endif %}[{{video_format}}] \
-{% if video_codec == 'HEVC' %}[HEVC] {%endif%}\
-[{{audio_codec}}].{{ext}}"
+{% if video_codec == 'HEVC' %}[HEVC] {% endif %}\
+[{{audio_codec}}]\
+{% if parts_count > 1 %} [Part {{part}}]{% endif %}\
+.{{ext}}"
 TV_TEMPLATE: "{{target_path}}/TV/{{title}}/{{title}} S{{ tv_season | prepend: '0' | slice: -2, 2 }}/\
-{{title}} S{{tv_season | prepend: '0' | slice: -2, 2 }}E{{tv_episode | prepend: '0' | slice: -2, 2 }} [{{video_format}}].{{ext}}"
+{{title}} S{{tv_season | prepend: '0' | slice: -2, 2 }}E{{tv_episode | prepend: '0' | slice: -2, 2 }}\
+ [{{video_format}}]{% if parts_count > 1 %} [Part {{part}}]{% endif %}\
+.{{ext}}"

--- a/lib/media_rename/movie_template.rb
+++ b/lib/media_rename/movie_template.rb
@@ -4,12 +4,14 @@ module MediaRename
 
     attr_reader :template, :attributes
 
-    def initialize(record:, media:)
+    def initialize(record:, media:, part:)
       @template   = Liquid::Template.parse(SETTINGS['MOVIE_TEMPLATE'], error_mode: :strict)
       @media      = media
       @attributes = {
         title: record.title.to_s.gsub(':', '-'),
         year: record.year,
+        parts_count: @media.parts.count,
+        part: part,
         video_format: MediaRename::Media.video_format(media.width, media.height),
         video_codec: MediaRename::Media.video_codec(media.video_codec),
         audio_codec: MediaRename::Media.audio_codec(media.audio_codec, media.audio_channels),

--- a/lib/media_rename/renamers/plex_renamer.rb
+++ b/lib/media_rename/renamers/plex_renamer.rb
@@ -41,13 +41,20 @@ module MediaRename
       plexrecord = library.find_by_filename(file)
       log.debug("No plex record found for [#{file}]") && return unless plexrecord
 
+      part = 1
       if library.movie_library?
         media = plexrecord.find_by_filename(file)
-        File.join(target_path, MediaRename::MovieTemplate.new({record: plexrecord, media: media}).render)
+        if media.parts.size > 1
+          part = media.parts.find_index {|part| part.has_file?(file)} + 1
+        end
+        File.join(target_path, MediaRename::MovieTemplate.new({record: plexrecord, media: media, part: part}).render)
       else
         episode = plexrecord.find_by_filename(file)
         media   = episode.media_by_filename(file)
-        File.join(target_path, MediaRename::ShowTemplate.new({record: episode, media: media}).render)
+        if media.parts.size > 1
+          part = media.parts.find_index {|part| part.has_file?(file)} + 1
+        end
+        File.join(target_path, MediaRename::ShowTemplate.new({record: episode, media: media, part: part}).render)
       end
     end
 

--- a/lib/media_rename/version.rb
+++ b/lib/media_rename/version.rb
@@ -1,3 +1,3 @@
 module MediaRename
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/fixtures/movie_with_parts.json
+++ b/test/fixtures/movie_with_parts.json
@@ -1,0 +1,139 @@
+{
+  "ratingKey": "12568",
+  "key": "/library/metadata/12568",
+  "guid": "com.plexapp.agents.imdb://tt1132620?lang=en",
+  "studio": "Det Danske Filminstitut",
+  "type": "movie",
+  "title": "The Girl with the Dragon Tattoo",
+  "titleSort": "Girl with the Dragon Tattoo",
+  "originalTitle": "Män som hatar kvinnor",
+  "contentRating": "R",
+  "summary": "Swedish thriller based on Stieg Larsson's novel about a male journalist and a young female hacker. In the opening of the movie, Mikael Blomkvist, a middle-aged publisher for the magazine Millennium, loses a libel case brought by corrupt Swedish industrialist Hans-Erik Wennerström. Nevertheless, he is hired by Henrik Vanger in order to solve a cold case, the disappearance of Vanger's niece",
+  "rating": 8.5,
+  "audienceRating": 8.7,
+  "year": 2009,
+  "tagline": "Based on the Worldwide Best Seller",
+  "thumb": "/library/metadata/12568/thumb/1612799370",
+  "art": "/library/metadata/12568/art/1612799370",
+  "duration": 5580926,
+  "originallyAvailableAt": "2009-02-27",
+  "addedAt": 1606333464,
+  "updatedAt": 1612799370,
+  "audienceRatingImage": "rottentomatoes://image.rating.upright",
+  "chapterSource": "media",
+  "primaryExtraKey": "/library/metadata/19659",
+  "ratingImage": "rottentomatoes://image.rating.ripe",
+  "Media": [
+    {
+      "id": 43367,
+      "duration": 5580926,
+      "bitrate": 7181,
+      "width": 1920,
+      "height": 1080,
+      "aspectRatio": 1.78,
+      "audioChannels": 6,
+      "audioCodec": "aac",
+      "videoCodec": "hevc",
+      "videoResolution": "1080",
+      "container": "mkv",
+      "videoFrameRate": "24p",
+      "audioProfile": "lc",
+      "videoProfile": "main 10",
+      "Part": [
+        {
+          "id": 43506,
+          "key": "/library/parts/43506/1612656506/file.mkv",
+          "duration": 5580926,
+          "file": "/volume2/Media/Movies/The Girl with the Dragon Tattoo (2009)/The Girl with the Dragon Tattoo (2009) [1080p] [HEVC] [AAC 5.1].mkv",
+          "size": 5009771867,
+          "audioProfile": "lc",
+          "container": "mkv",
+          "hasThumbnail": "1",
+          "videoProfile": "main 10"
+        }
+      ]
+    },
+    {
+      "id": 43477,
+      "duration": 11161659,
+      "bitrate": 7192,
+      "width": 1920,
+      "height": 1080,
+      "aspectRatio": 1.78,
+      "audioChannels": 6,
+      "audioCodec": "aac",
+      "videoCodec": "hevc",
+      "videoResolution": "1080",
+      "container": "mkv",
+      "videoFrameRate": "24p",
+      "audioProfile": "lc",
+      "videoProfile": "main 10",
+      "Part": [
+        {
+          "id": 43630,
+          "key": "/library/parts/43630/1612799323/file.mkv",
+          "duration": 5580734,
+          "file": "/volume2/Media/downloads/The Girl with the Dragon Tattoo (2009) TV Extended Edition (1080p BluRay x265 HEVC 10bit AAC 5.1 Swedish r00t)/The Girl with the Dragon Tattoo (2009) Extended TV Edition Part 1 (1080p BluRay x265 r00t).mkv",
+          "size": 4997729618,
+          "audioProfile": "lc",
+          "container": "mkv",
+          "hasThumbnail": "1",
+          "videoProfile": "main 10"
+        },
+        {
+          "id": 43631,
+          "key": "/library/parts/43631/1612799336/file.mkv",
+          "duration": 5580925,
+          "file": "/volume2/Media/downloads/The Girl with the Dragon Tattoo (2009) TV Extended Edition (1080p BluRay x265 HEVC 10bit AAC 5.1 Swedish r00t)/The Girl with the Dragon Tattoo (2009) Extended TV Edition Part 2 (1080p BluRay x265 r00t).mkv",
+          "size": 5009771867,
+          "audioProfile": "lc",
+          "container": "mkv",
+          "hasThumbnail": "1",
+          "videoProfile": "main 10"
+        }
+      ]
+    }
+  ],
+  "Genre": [
+    {
+      "tag": "Crime"
+    },
+    {
+      "tag": "Thriller"
+    }
+  ],
+  "Director": [
+    {
+      "tag": "Niels Arden Oplev"
+    }
+  ],
+  "Writer": [
+    {
+      "tag": "Nikolaj Arcel"
+    },
+    {
+      "tag": "Rasmus Heisterberg"
+    }
+  ],
+  "Country": [
+    {
+      "tag": "USA"
+    }
+  ],
+  "Collection": [
+    {
+      "tag": "The Millennium"
+    }
+  ],
+  "Role": [
+    {
+      "tag": "Michael Nyqvist"
+    },
+    {
+      "tag": "Noomi Rapace"
+    },
+    {
+      "tag": "Lena Endre"
+    }
+  ]
+}

--- a/test/fixtures/parts.json
+++ b/test/fixtures/parts.json
@@ -1,0 +1,40 @@
+{
+  "id": 43477,
+  "duration": 11161659,
+  "bitrate": 7192,
+  "width": 1920,
+  "height": 1080,
+  "aspectRatio": 1.78,
+  "audioChannels": 6,
+  "audioCodec": "aac",
+  "videoCodec": "hevc",
+  "videoResolution": "1080",
+  "container": "mkv",
+  "videoFrameRate": "24p",
+  "audioProfile": "lc",
+  "videoProfile": "main 10",
+  "Part": [
+    {
+      "id": 43630,
+      "key": "/library/parts/43630/1612799323/file.mkv",
+      "duration": 5580734,
+      "file": "/volume2/Media/downloads/The Girl with the Dragon Tattoo (2009) TV Extended Edition (1080p BluRay x265 HEVC 10bit AAC 5.1 Swedish r00t)/The Girl with the Dragon Tattoo (2009) Extended TV Edition Part 1 (1080p BluRay x265 r00t).mkv",
+      "size": 4997729618,
+      "audioProfile": "lc",
+      "container": "mkv",
+      "hasThumbnail": "1",
+      "videoProfile": "main 10"
+    },
+    {
+      "id": 43631,
+      "key": "/library/parts/43631/1612799336/file.mkv",
+      "duration": 5580925,
+      "file": "/volume2/Media/downloads/The Girl with the Dragon Tattoo (2009) TV Extended Edition (1080p BluRay x265 HEVC 10bit AAC 5.1 Swedish r00t)/The Girl with the Dragon Tattoo (2009) Extended TV Edition Part 2 (1080p BluRay x265 r00t).mkv",
+      "size": 5009771867,
+      "audioProfile": "lc",
+      "container": "mkv",
+      "hasThumbnail": "1",
+      "videoProfile": "main 10"
+    }
+  ]
+}


### PR DESCRIPTION
Ability to handle renaming of media that has multiple parts.
Some media might be broken into multiple parts - this handles it my allowing you to add in the template a [part 1], etc. if media has more than 1 part.